### PR TITLE
Update remote-confirm to use RemoteHelper#triggerChanges

### DIFF
--- a/dist/bellhopper.js
+++ b/dist/bellhopper.js
@@ -191,7 +191,7 @@
         url: config['remote-url'],
         method: config['remote-method']
       }).done(function() {
-        return UpdateableViews.updateViewsForModel(config['mutates-models']);
+        return RemoteHelpers.triggerChange(config['mutates-models']);
       });
     }
   };

--- a/dist/remote-confirm.js
+++ b/dist/remote-confirm.js
@@ -8,7 +8,7 @@
         url: config['remote-url'],
         method: config['remote-method']
       }).done(function() {
-        return UpdateableViews.updateViewsForModel(config['mutates-models']);
+        return RemoteHelpers.triggerChange(config['mutates-models']);
       });
     }
   };

--- a/dist/tests.js
+++ b/dist/tests.js
@@ -264,8 +264,8 @@ describe('Remote Confirm', function() {
       server.restore();
       return window.confirm = actualConfirm;
     });
-    return it("calls UpdatableViews.updateViewsForModel() with the mutated model", function() {
-      var element, mutatedModels, remoteMethod, remoteUrl, server, updateViewsStub;
+    return it("triggers an update for the mutated model", function() {
+      var element, mutatedModels, remoteMethod, remoteUrl, server, triggerChangeStub;
       window.confirm = function() {
         return true;
       };
@@ -279,12 +279,12 @@ describe('Remote Confirm', function() {
           "Content-Type": "text/html"
         }, "OK"
       ]);
-      updateViewsStub = sinon.stub(UpdateableViews, 'updateViewsForModel', function() {});
+      triggerChangeStub = sinon.stub(RemoteHelpers, 'triggerChange', function() {});
       RemoteConfirm(element);
       server.respond();
-      expect(updateViewsStub.calledWith(mutatedModels)).toBeTruthy();
+      expect(triggerChangeStub.calledWith(mutatedModels)).toBeTruthy();
       server.restore();
-      updateViewsStub.restore();
+      triggerChangeStub.restore();
       return window.confirm = actualConfirm;
     });
   });

--- a/src/remote-confirm.coffee
+++ b/src/remote-confirm.coffee
@@ -8,7 +8,7 @@ window.RemoteConfirm = (srcEl)->
       url: config['remote-url']
       method: config['remote-method']
     ).done(->
-      UpdateableViews.updateViewsForModel(config['mutates-models'])
+      RemoteHelpers.triggerChange(config['mutates-models'])
     )
 
 RemoteHelpers.onDataAction('remote_confirm', 'click', (event) ->

--- a/tests/unit/remote_confirm_spec.coffee
+++ b/tests/unit/remote_confirm_spec.coffee
@@ -29,7 +29,7 @@ describe 'Remote Confirm', ->
       server.restore()
       window.confirm = actualConfirm
 
-    it "calls UpdatableViews.updateViewsForModel() with the mutated model", ->
+    it "triggers an update for the mutated model", ->
       window.confirm = -> true
       remoteUrl = "/waffles"
       remoteMethod = "DELETE"
@@ -44,18 +44,18 @@ describe 'Remote Confirm', ->
       server.respondWith(remoteUrl,
         [201, { "Content-Type": "text/html" }, "OK"])
 
-      updateViewsStub = sinon.stub(
-        UpdateableViews, 'updateViewsForModel', ->)
+      triggerChangeStub = sinon.stub(
+        RemoteHelpers, 'triggerChange', ->)
 
       RemoteConfirm(element)
       server.respond()
 
       expect(
-        updateViewsStub.calledWith(mutatedModels)
+        triggerChangeStub.calledWith(mutatedModels)
       ).toBeTruthy()
 
       server.restore()
-      updateViewsStub.restore()
+      triggerChangeStub.restore()
       window.confirm = actualConfirm
 
   describe 'when the dialog is rejected', ->


### PR DESCRIPTION
This brings it into line with the behaviour of remote-action and allows models to listen for changes on adds/deletes
